### PR TITLE
Updated imported module references for Python MCP SDK 1.2.0

### DIFF
--- a/src/mcp_server_ds/server.py
+++ b/src/mcp_server_ds/server.py
@@ -15,7 +15,8 @@ from mcp.types import (
     GetPromptResult,
     PromptMessage,
 )
-from mcp.server import NotificationOptions, Server, McpError
+from mcp.server.lowlevel import NotificationOptions, Server
+from mcp.shared.exceptions import McpError
 from pydantic import AnyUrl
 import mcp.server.stdio
 from pydantic import BaseModel


### PR DESCRIPTION
Fixed the import lines in server.py, as it currently errors from recent Python MCP SDK changes.